### PR TITLE
[스타일 추가 작업] 모바일 화면에서 본문 좁게 보이는 현상 해결본 통합

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -496,7 +496,21 @@ section.hidden {
 
 /* 반응형 */
 @media (max-width: 600px) {
+  /* textarea, 카드컨테이너, 리포트 등 폭 제한한 요소 */
+  textarea#question-input,
+  #question-reminder,
+  #report,
+  #selected-cards,
+  #card-container {
+    max-width: 90%;
+    width: 100%;
+  }
+
   #container {
+    padding: 1rem;
+  }
+
+  section {
     padding: 1rem;
   }
 
@@ -548,17 +562,56 @@ section.hidden {
 }
 
 @media (max-width: 400px) {
+  textarea#question-input,
+  #question-reminder,
+  #report,
+  #selected-cards,
+  #card-container {
+    max-width: 98%;
+  }
+
+  section {
+    padding: 0.25rem;
+  }
+
+  h2 {
+    font-size: 1.2rem;
+  }
+
   .tarot-card,
   .selected-card {
-    width: 80px;
+    width: 65px;
     aspect-ratio: 3 / 5;
   }
 
+  #drawn-cards,
+  #selected-cards {
+    gap: 0.5rem;
+  }
+
   #card-container {
-    height: 160px;
+    height: 150px;
   }
 
   #landing h1 {
-    font-size: 2.5rem;
+    font-size: 2.2rem;
+  }
+
+  #landing p {
+    font-size: 1rem;
+  }
+
+  button,
+  .home-btn.reset,
+  #start-btn,
+  #go-to-draw,
+  #get-result,
+  #retry {
+    font-size: 0.9rem;
+    padding: 0.5rem 1rem;
+  }
+
+  #result-output {
+    font-size: 0.9rem;
   }
 }


### PR DESCRIPTION
모바일 환경에서 콘텐츠(텍스트, 버튼, 입력창 등)가 지나치게 좁게 렌더링되는 현상 개선
모바일 뷰포트에 맞게 max-width와 padding을 조정해 가독성과 UI 개선